### PR TITLE
Rework map entity collections

### DIFF
--- a/Characters/Enemies/BasicEnemy/basic_enemy.gd
+++ b/Characters/Enemies/BasicEnemy/basic_enemy.gd
@@ -13,16 +13,12 @@ extends Node2D
 		if is_node_ready():
 			shoot_player_controller.node_to_put_bullets_in = node_to_put_nodes_in
 			pickup_spawner.node_to_spawn_pickup_in = node_to_put_nodes_in
-@export var level_map_entity_collection: MapEntityCollection
 
 func _ready():
 	map_entity.get_position = func(): return body.global_position
 	map_entity.source_node = self
 	map_texture_updater.map_texture = map_entity
-	if level_map_entity_collection:
-		level_map_entity_collection.add_map_entity(map_entity)
-	else:
-		push_warning("missing level map MapEntityInjector")
+	EventBus.emit_map_entity_added(map_entity)
 	shoot_player_controller.node_to_put_bullets_in = node_to_put_nodes_in
 	pickup_spawner.node_to_spawn_pickup_in = node_to_put_nodes_in
 

--- a/Characters/Player/PlayerCharacterController/player_character_controller.gd
+++ b/Characters/Player/PlayerCharacterController/player_character_controller.gd
@@ -150,7 +150,7 @@ func _ready():
 	#power_pole_selection_state.toggle_map = func(): return Input.is_action_just_pressed("test_input")
 	power_pole_selection_state.environment_query_system = environment_query_system
 	power_pole_selection_state.get_revealed_sectors = get_revealed_sectors
-	level_map_map_entity_collection.add_map_entity(map_texture)
+	EventBus.emit_map_entity_added(map_texture)
 	level_map_state.toggle_map = func(): return Input.is_action_just_pressed("toggle_map")
 	level_map_state.environment_query_system = environment_query_system
 	level_map_state.map_entity_collection = level_map_map_entity_collection

--- a/Objects/Shelter/shelter.gd
+++ b/Objects/Shelter/shelter.gd
@@ -1,13 +1,11 @@
 class_name Shelter extends Node2D
 
-@export var level_map_map_entity_collection: MapEntityCollection
 @export var map_scene: MapScene
 @export var selectable_map_entity: SelectableMapEntity
 @export var shelter_selection_texture: Texture
 
 func _ready():
-	if level_map_map_entity_collection:
-		level_map_map_entity_collection.add_map_entity(map_scene)
+	EventBus.emit_map_entity_added(map_scene)
 	map_scene.scene_setup.connect(_set_map_entity_position)
 
 func make_selectable_map_entity() -> SelectableMapEntity:

--- a/Singletons/event_bus.gd
+++ b/Singletons/event_bus.gd
@@ -1,0 +1,6 @@
+extends Node
+
+signal map_entity_added(map_entity: MapEntity)
+
+func emit_map_entity_added(map_entity: MapEntity) -> void:
+	map_entity_added.emit(map_entity)

--- a/World/Levels/level_2.tscn
+++ b/World/Levels/level_2.tscn
@@ -151,33 +151,29 @@ position = Vector2(1824, 288)
 [node name="PoweredDoor2" parent="." index="22" instance=ExtResource("11_pl7cp")]
 position = Vector2(1440, 352)
 
-[node name="BasicEnemy" parent="." index="23" node_paths=PackedStringArray("target", "node_to_put_nodes_in", "level_map_entity_collection") instance=ExtResource("12_5j21r")]
+[node name="BasicEnemy" parent="." index="23" node_paths=PackedStringArray("target", "node_to_put_nodes_in") instance=ExtResource("12_5j21r")]
 position = Vector2(624, 224)
 map_entity = SubResource("Resource_ehmki")
 target = NodePath("../PlayerTarget")
 node_to_put_nodes_in = NodePath("..")
-level_map_entity_collection = NodePath("../LevelMapMapEntityCollection")
 
-[node name="BasicEnemy2" parent="." index="24" node_paths=PackedStringArray("target", "node_to_put_nodes_in", "level_map_entity_collection") instance=ExtResource("12_5j21r")]
+[node name="BasicEnemy2" parent="." index="24" node_paths=PackedStringArray("target", "node_to_put_nodes_in") instance=ExtResource("12_5j21r")]
 position = Vector2(672, 224)
 map_entity = SubResource("Resource_acg51")
 target = NodePath("../PlayerTarget")
 node_to_put_nodes_in = NodePath("..")
-level_map_entity_collection = NodePath("../LevelMapMapEntityCollection")
 
-[node name="BasicEnemy3" parent="." index="25" node_paths=PackedStringArray("target", "node_to_put_nodes_in", "level_map_entity_collection") instance=ExtResource("12_5j21r")]
+[node name="BasicEnemy3" parent="." index="25" node_paths=PackedStringArray("target", "node_to_put_nodes_in") instance=ExtResource("12_5j21r")]
 position = Vector2(1120, 400)
 map_entity = SubResource("Resource_1jdlk")
 target = NodePath("../PlayerTarget")
 node_to_put_nodes_in = NodePath("..")
-level_map_entity_collection = NodePath("../LevelMapMapEntityCollection")
 
-[node name="BasicEnemy4" parent="." index="26" node_paths=PackedStringArray("target", "node_to_put_nodes_in", "level_map_entity_collection") instance=ExtResource("12_5j21r")]
+[node name="BasicEnemy4" parent="." index="26" node_paths=PackedStringArray("target", "node_to_put_nodes_in") instance=ExtResource("12_5j21r")]
 position = Vector2(1392, 608)
 map_entity = SubResource("Resource_xe2t3")
 target = NodePath("../PlayerTarget")
 node_to_put_nodes_in = NodePath("..")
-level_map_entity_collection = NodePath("../LevelMapMapEntityCollection")
 
 [node name="PowerSupply4" parent="." index="27" instance=ExtResource("9_wnkks")]
 position = Vector2(1264, -16)

--- a/World/Levels/level_2.tscn
+++ b/World/Levels/level_2.tscn
@@ -111,15 +111,13 @@ position = Vector2(128, -32)
 height = 192
 tile_height = 12.0
 
-[node name="Shelter" parent="." index="13" node_paths=PackedStringArray("level_map_map_entity_collection") instance=ExtResource("6_raav1")]
+[node name="Shelter" parent="." index="13" instance=ExtResource("6_raav1")]
 position = Vector2(0, 144)
-level_map_map_entity_collection = NodePath("../LevelMapMapEntityCollection")
 map_scene = SubResource("Resource_oj4ej")
 selectable_map_entity = SubResource("Resource_447tw")
 
-[node name="Shelter2" parent="." index="14" node_paths=PackedStringArray("level_map_map_entity_collection") instance=ExtResource("6_raav1")]
+[node name="Shelter2" parent="." index="14" instance=ExtResource("6_raav1")]
 position = Vector2(1456, 144)
-level_map_map_entity_collection = NodePath("../LevelMapMapEntityCollection")
 map_scene = SubResource("Resource_6c7hc")
 selectable_map_entity = SubResource("Resource_8ej7a")
 

--- a/World/map_entity_collection.gd
+++ b/World/map_entity_collection.gd
@@ -6,6 +6,9 @@ extends Node
 signal map_entity_added(map_entity: MapEntity)
 signal map_entity_removed(map_entity: MapEntity)
 
+func _ready():
+	EventBus.map_entity_added.connect(add_map_entity)
+
 func add_map_entity(map_entity: MapEntity) -> void:
 	_map_entities.append(map_entity)
 	map_entity_added.emit(map_entity)

--- a/project.godot
+++ b/project.godot
@@ -20,6 +20,7 @@ config/icon="res://icon.svg"
 
 PowerConnectionHandler="*res://Singletons/power_connection_handler.gd"
 MouseArea="*res://Singletons/MouseArea/mouse_area.tscn"
+EventBus="*res://Singletons/event_bus.gd"
 
 [display]
 


### PR DESCRIPTION
now uses an event bus instead of injecting the entity collection, to keep the collections decoupled from the entities.